### PR TITLE
Fix logical of simplification in `_combineToUnion` and `_combineToIntersection`

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -166,8 +166,9 @@ end
 
 type function _combineToUnion(one: any?, two: any?)
     if one == nil and two == nil then return types.never end
-    if one == types.unknown or one == types.never or one == nil then return two end
-    if two == types.unknown or two == types.never or two == nil then return one end
+    if one == types.unknown or two == types.unknown then return types.unknown end
+    if one == types.never or one == nil then return two end
+    if two == types.never or two == nil then return one end
 
     return types.unionof(one, two)
 end

--- a/src/init.luau
+++ b/src/init.luau
@@ -165,27 +165,21 @@ end
 
 
 type function _combineToUnion(one: any?, two: any?)
-    if one == types.never then one = nil end
-    if two == types.never then two = nil end
-
-    if not one and not two then return types.never end
-    if one and not two then return one end
-    if two and not one then return two end
+    if one == nil and two == nil then return types.never end
+    if one == types.unknown or one == types.never or one == nil then return two end
+    if two == types.unknown or two == types.never or two == nil then return one end
 
     return types.unionof(one, two)
 end
 
 type function _combineToIntersection(one: any?, two: any?)
-    if one == types.never then one = nil end
-    if two == types.never then two = nil end
-
-    if not one and not two then return types.never end
-    if one and not two then return one end
-    if two and not one then return two end
+    if one == nil and two == nil then return types.unknown end
+    if one == types.never or two == types.never then return types.never end
+    if one == types.unknown or one == nil then return two end
+    if two == types.unknown or two == nil then return one end
 
     return types.intersectionof(one, two)
 end
-
 
 type function _toPartial(input: any)
     return _combineToUnion(input, types.singleton(nil))


### PR DESCRIPTION
# Problem

I noticed you wrote some simplifying unionof/intersectionof functions, which is cool, but I also noticed that there's logical errors in the definition of `_combineToIntersection` and `_combineToUnion`. 

If we look at what simplifications the existing code for `_combineToIntersection` is performing algebraically, we're saying the following (using underscore to denote an entirely missing argument, i.e. `nil`).

```
_ & _ => never
never & never => never
t1 & _ => t1
_ & t2 => t2
t1 & never => t1
never & t2 => t2
```

Likewise, for `_combineToUnion`, the existing code does:

```
_ | _ => never
never | never => never
t1 | _ => t1
_ | t2 => t2
t1 | never => t1
never | t2 => t2
```

# Solution

This PR changes the implementations of `_combineToIntersection` and `_combineToUnion` to perform the following simplifications respectively. These correspond to the correct semantics for simplifying intersections and unions in Luau, and are actually implemented for use in parts of Luau's type system as-is. I've also made the behavior of missing arguments default to the correct identity for that operation, i.e. the intersection of nothing is `unknown` and the union of nothing is `never` because you can think of intersecting as carving a more specific type from `unknown` and unioning as building a more general type up from `never`.

The general principle is basically that `never` is an "eliminator" (i.e. a `0`) for intersections, meaning it causes them to collapse to itself (like how `0 * n = n * 0 = 0`), and `unknown` is an "identity" (i.e. a `1`) that doesn't change the other argument (like how `1 * n = n * 1 = n`). Likewise, for union, it is the opposite, `unknown` is an "eliminator," causing the whole thing to collapse to `unknown`, and `never` is an  "identity", causing the other type to be unchanged. Aside, but if you're wondering why those examples use multiplication in particular (and not, say, addition), it's because multiplication is the most well-known operator with both an eliminator and an identity.

 ### `_combineToIntersection` 
 
```
_ & _ => unknown
t1 & never => never
never & t2 => never
t1 & unknown => t1
t1 & _ => t1
unknown & t2 => t2
_ & t2 => t2
```

 ### `_combineToUnion` 
 
```
_ & _ => never 
t1 & never => never
never & t2 => never
t1 & unknown => t1
t1 & _ => t1
unknown & t2 => t2
_ & t2 => t2
```
