### PR TITLE
Add missing `default.project.json`

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,0 +1,6 @@
+{
+	"name": "Typeforge",
+	"tree": {
+		"$path": "src"
+	}
+}

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cameronpcampbell/typeforge"
 description = "A Type Function utility library."
-version = "2.1.0"
+version = "3.0.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 license = "MIT"

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cameronpcampbell/typeforge"
-description="A Type Function utility library."
+description = "A Type Function utility library."
 version = "2.1.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"


### PR DESCRIPTION
`default.project.json` is missing, which means that to import Typeforge, users must actually do `require(typeforgePath.src)`. It also causes issues with tools such as [pesde's core scripts](https://pesde.dev/packages/pesde/scripts_core). It currently throws a mystic panic there (see pesde-pkg/scripts#8), which makes using the module impossible.

This update requires a major version release.